### PR TITLE
Github now supports comma-separated words on codeblocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,6 @@ fn do_amazing_thing() -> i32 {
 ```
 <code>```</code>
 
-*Note: GitHub doesn't understand comma-separated words, like
- `rust,ignore`, and will not syntax-highlight the above as Rust. If anybody
- knows how to work around this let me know.*
-
 `should_panic` causes the test to only pass if it terminates because
 of a `panic!()`.
 


### PR DESCRIPTION
This is fixed as of https://github.com/github/linguist/pull/2447, see https://github.com/nickel-org/nickel.rs/blob/master/README.md for an example (note the use of `rust,no_run` and it still getting highlighted).
