### PR TITLE
Remove the wildcard dependencies in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Put this in `Cargo.toml` to add the `skeptic` dependency:
 
 ```toml
 [build-dependencies]
-skeptic = "*"
+skeptic = "0.4"
 
 [dev-dependencies]
-skeptic = "*"
+skeptic = "0.4"
 ```
 
 Also in `Cargo.toml`, to the `[package]` section add:


### PR DESCRIPTION
crates.io is now rejecting wildcard deps and they are a bad idea anyway
