### PR TITLE
Fix no_run

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 extern crate skeptic;
 
 fn main() {
-    skeptic::generate_doc_tests(&["README.md", "template-example.md", "tests/hashtag-test.md"]);
+    skeptic::generate_doc_tests(&["README.md", "template-example.md", "tests/hashtag-test.md", "tests/should-panic-test.md"]);
 }

--- a/tests/should-panic-test.md
+++ b/tests/should-panic-test.md
@@ -1,0 +1,19 @@
+Rust code that should panic when running it.
+
+```rust,should_panic
+fn main() {
+  panic!("I should panic");
+}
+```
+
+Rust code that should panic when compiling it.
+
+```rust,no_run,should_panic
+fn add(a: u32, b: u32) -> u32 {
+    a + b
+}
+
+fn main() {
+  add(1);
+}
+```


### PR DESCRIPTION
Currently code marked with "no_run" gets written to a intermediate test file as a string, but is never actually compiled.
With this patch the code gets compiled but not run.
