### PR TITLE
Only overwrite the generated test file when it is not modified

### DIFF
--- a/src/skeptic/lib.rs
+++ b/src/skeptic/lib.rs
@@ -107,7 +107,7 @@ fn extract_tests_from_file(path: &Path) -> Result<DocTest, IoError> {
                 let code_block_info = parse_code_block_info(info);
                 if let Some(buf) = code_buffer.take() {
                     if code_block_info.is_template {
-                        template = Some(join_strings(buf))
+                        template = Some(buf.into_iter().collect())
                     } else {
                         tests.push(Test {
                             name: test_name_gen.advance(),
@@ -127,15 +127,6 @@ fn extract_tests_from_file(path: &Path) -> Result<DocTest, IoError> {
         template: template,
         tests: tests,
     })
-}
-
-fn join_strings(ss: Vec<String>) -> String {
-    let mut s_ = String::new();
-    for s in ss {
-        s_.push_str(&s)
-    }
-
-    s_
 }
 
 struct TestNameGen {

--- a/src/skeptic/lib.rs
+++ b/src/skeptic/lib.rs
@@ -16,6 +16,12 @@ pub fn generate_doc_tests(docs: &[&str]) {
         return;
     }
 
+    // Inform cargo that it needs to rerun the build script if one of the
+    // skeptic files are modified
+    for doc in docs {
+        println!("cargo:rerun-if-changed={}", doc);
+    }
+
     let out_dir = env::var("OUT_DIR").unwrap();
     let cargo_manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
 

--- a/src/skeptic/lib.rs
+++ b/src/skeptic/lib.rs
@@ -346,7 +346,8 @@ pub mod rt {
         let mut deps_dir = target_dir.clone();
         deps_dir.push("deps");
 
-        interpret_output(Command::new(rustc)
+        interpret_output("compile",
+                         Command::new(rustc)
                              .arg(in_path)
                              .arg("-o")
                              .arg(out_path)
@@ -359,12 +360,13 @@ pub mod rt {
                              .unwrap());
     }
     fn run_test_case(out_path: &Path) {
-        interpret_output(Command::new(out_path)
+        interpret_output("run",
+                         Command::new(out_path)
                              .output()
                              .unwrap());
     }
 
-    fn interpret_output(output: Output) {
+    fn interpret_output(command: &str, output: Output) {
         write!(io::stdout(),
                "{}",
                String::from_utf8(output.stdout).unwrap())
@@ -374,7 +376,7 @@ pub mod rt {
                String::from_utf8(output.stderr).unwrap())
             .unwrap();
         if !output.status.success() {
-            panic!("command failed");
+            panic!("command `{}` failed", command);
         }
     }
 }


### PR DESCRIPTION
By avoiding to overwrite the file which contains the generated skeptic tests when it is not necessary we give cargo a chance to avoid recompiling the file as long as the dependencies has not changed.

Partial fix for #8.
