### PR TITLE
Update pulldown-cmark to 0.0.8

### DIFF
--- a/src/skeptic/Cargo.toml
+++ b/src/skeptic/Cargo.toml
@@ -11,5 +11,5 @@ name = "skeptic"
 path = "lib.rs"
 
 [dependencies]
-pulldown-cmark = "0.0.3"
+pulldown-cmark = "0.0.8"
 tempdir = "0.3.4"


### PR DESCRIPTION
pulldown-cmark is showing up twice in my lockfile because the version rust-skeptic uses is quite out of date :)