### PR TITLE
solve two clippy lints

### DIFF
--- a/src/skeptic/lib.rs
+++ b/src/skeptic/lib.rs
@@ -257,7 +257,7 @@ fn create_test_string(config: &Config,
 
     try!(writeln!(s, "#[test] fn {}() {{", test.name));
     try!(writeln!(s,
-                  "    let ref s = format!(\"{}\", r####\"{}\"####);",
+                  "    let s = &format!(\"{}\\n\", r####\"{}\"####);",
                   template,
                   test_text));
 


### PR DESCRIPTION
When I run clippy on https://github.com/colin-kiegel/rust-derive-builder it emits two lints about the auto-generated code from `skeptic`. This simple change solves both:

- [toplevel_ref_arg](https://github.com/Manishearth/rust-clippy/wiki#toplevel_ref_arg)
  `let ref s = ...` -> `let s = &...`
- [useless_format](https://github.com/Manishearth/rust-clippy/wiki#useless_format)
  `format!("{}", ...)` -> `format!("{}\n", ...)` (in case of no template)