### PR TITLE
Update pulldown-cmark and bump version

### DIFF
--- a/src/skeptic/Cargo.toml
+++ b/src/skeptic/Cargo.toml
@@ -4,10 +4,10 @@ description = "Test your Rust markdown documentation via Cargo"
 license = "MIT/Apache-2.0"
 name = "skeptic"
 repository = "https://github.com/brson/rust-skeptic"
-version = "0.10.0"
+version = "0.10.1"
 
 [dependencies]
-pulldown-cmark = "0.0.14"
+pulldown-cmark = "0.0.15"
 tempdir = "0.3.5"
 
 [lib]


### PR DESCRIPTION
Hi until https://github.com/brson/rust-skeptic/issues/18 is solved the dependency on old pulldown-cmark causes buildbreak in rust-cookbook https://github.com/brson/rust-cookbook/pull/192