### PR TITLE
Bump pulldown-cmark to 0.0.15 and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.10.1
+
+* [Update pulldown-cmark to 0.0.15]((https://github.com/brson/rust-skeptic/pull/33)
+
 # 0.10.0
 
 * [Force skeptic tests to be located in temporary directory](https://github.com/brson/rust-skeptic/pull/26)

--- a/src/skeptic/Cargo.toml
+++ b/src/skeptic/Cargo.toml
@@ -4,10 +4,10 @@ description = "Test your Rust markdown documentation via Cargo"
 license = "MIT/Apache-2.0"
 name = "skeptic"
 repository = "https://github.com/brson/rust-skeptic"
-version = "0.10.0"
+version = "0.10.1"
 
 [dependencies]
-pulldown-cmark = "0.0.14"
+pulldown-cmark = "0.0.15"
 tempdir = "0.3.5"
 
 [lib]


### PR DESCRIPTION
This is needed to update bitflags to 0.9 in servo.