### PR TITLE
corrected test errors with windows line endings on '#' hidden sections

### DIFF
--- a/src/skeptic/lib.rs
+++ b/src/skeptic/lib.rs
@@ -318,10 +318,11 @@ fn emit_tests(config: &Config, suite: DocTestSuite) -> Result<(), IoError> {
 /// testing.
 fn clean_omitted_line(line: &String) -> &str {
     let trimmed = line.trim_left();
-    if trimmed == "#\n" {
-        &trimmed[1..]
-    } else if trimmed.starts_with("# ") {
+
+    if trimmed.starts_with("# ") {
         &trimmed[2..]
+    } else if trimmed.starts_with("#") && !trimmed.starts_with("#[") {
+        &trimmed[1..]
     } else {
         line
     }

--- a/tests/hashtag-test.md
+++ b/tests/hashtag-test.md
@@ -6,3 +6,13 @@ fn main() {
   let _ = Person("#bors");
 }
 ```
+
+Rust code with hidden parts `"#` should be tested by skeptic without error.
+
+```rust
+# struct Person<'a>(&'a str);
+#
+fn main() {
+  let _ = Person("#bors");
+}
+```


### PR DESCRIPTION
fixes https://github.com/brson/rust-skeptic/issues/34

also added a test that currently fails on windows without this patch