### PR TITLE
Fix problem with duplicate dependency resolution

### DIFF
--- a/src/skeptic/Cargo.toml
+++ b/src/skeptic/Cargo.toml
@@ -9,6 +9,15 @@ version = "0.10.1"
 [dependencies]
 pulldown-cmark = "0.0.15"
 tempdir = "0.3.5"
+walkdir = "1.0"
+serde = "1.0.9"
+serde_derive = "1.0.9"
+serde_json = "1.0.2"
+toml = "0.4.2"
+
+[dependencies.error-chain]
+version = "0.10.0"
+default-features = false
 
 [lib]
 name = "skeptic"


### PR DESCRIPTION
It might not be the prettiest solution (and there are most likely some bugs left/introduced) but seams to work for duplicate dependencies in rust-cookbook.

- tested only on linux

side benefit is that tests are now actually faster as they are now only linked to the direct crate dependencies.

fixes https://github.com/brson/rust-skeptic/issues/18