### PR TITLE
Allow lines that begin with "#!", "#["

### DIFF
--- a/src/skeptic/lib.rs
+++ b/src/skeptic/lib.rs
@@ -325,8 +325,6 @@ fn clean_omitted_line(line: &String) -> &str {
 
     if trimmed.starts_with("# ") {
         &trimmed[2..]
-    } else if trimmed.starts_with("#") && !trimmed.starts_with("#[") {
-        &trimmed[1..]
     } else {
         line
     }

--- a/tests/hashtag-test.md
+++ b/tests/hashtag-test.md
@@ -1,4 +1,4 @@
-Rust code that includes a `"#` should be tested by skeptic without error.
+Rust code that includes a "`#`" should be tested by skeptic without error.
 
 ```rust
 struct Person<'a>(&'a str);
@@ -7,13 +7,13 @@ fn main() {
 }
 ```
 
-Rust code with hidden parts `"#` should be tested by skeptic without error.
+Rust code with hidden parts "`# `" should be tested by skeptic without error.
 
 ```rust
 # struct Person<'a>(&'a str);
 
 fn main() {
-  let _ = Person("#bors");
+  let _ = Person("bors");
 }
 ```
 
@@ -25,7 +25,7 @@ struct Person<'a>(&'a str);
 
 #[allow(unused_variables)]
 fn main() {
-  let p = Person("#bors");
+  let p = Person("bors");
 }
 ```
 
@@ -36,6 +36,6 @@ Rust code that uses crate-level attributes `"#!"` should be tested by skeptic wi
 
 struct Person<'a>(&'a str);
 fn main() {
-  let p = Person("#bors");
+  let p = Person("bors");
 }
 ```

--- a/tests/hashtag-test.md
+++ b/tests/hashtag-test.md
@@ -11,8 +11,31 @@ Rust code with hidden parts `"#` should be tested by skeptic without error.
 
 ```rust
 # struct Person<'a>(&'a str);
-#
+
 fn main() {
   let _ = Person("#bors");
+}
+```
+
+Rust code that uses attributes `"#["` should be tested by skeptic without error.
+
+```rust
+
+struct Person<'a>(&'a str);
+
+#[allow(unused_variables)]
+fn main() {
+  let p = Person("#bors");
+}
+```
+
+Rust code that uses crate-level attributes `"#!"` should be tested by skeptic without error.
+
+```rust
+#![allow(unused_variables)]
+
+struct Person<'a>(&'a str);
+fn main() {
+  let p = Person("#bors");
 }
 ```


### PR DESCRIPTION
This fixes #39 .

Question: Should this test compile, by ignoring the second line which is a single "#" without a trailing space?
```rust
# struct Person<'a>(&'a str);
#
fn main() {
  let _ = Person("bors");
}
```
The existing test expected this to pass, but it now does not. rustdoc does not seem to let that through, so I've mirrored the result here.