### PR TITLE
fix failing test under windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ fn main() {
     // Add all markdown files in directory "book/".
     let mut mdbook_files = markdown_files_of_directory("book/");
     // Also add "README.md" to the list of files.
-    mdbook_files.push("README.md".to_owned());
+    mdbook_files.push("README.md".into());
     generate_doc_tests(&mdbook_files);
 }
 ```


### PR DESCRIPTION
This test was failing under windows due to the path separator.
This works under Linux and Windows. (Just in case you get other Windows contributors)
Hope you don't mind.