### PR TITLE
Don't check for changes in skt.md files that don't exist

### DIFF
--- a/src/skeptic/lib.rs
+++ b/src/skeptic/lib.rs
@@ -98,7 +98,11 @@ where
     // modified
     for doc in &docs {
         println!("cargo:rerun-if-changed={}", doc);
-        println!("cargo:rerun-if-changed={}.skt.md", doc);
+
+        let skt = format!("{}.skt.md", doc);
+        if Path::new(&skt).exists() {
+            println!("cargo:rerun-if-changed={}", skt);
+        }
     }
 
     let out_dir = env::var("OUT_DIR").unwrap();


### PR DESCRIPTION
Fixes #25. Workaround for rust-lang/cargo#4213.