### PR TITLE
Remove single usage of struct field shorthands to compile on rust 1.16

### DIFF
--- a/src/skeptic/lib.rs
+++ b/src/skeptic/lib.rs
@@ -116,7 +116,7 @@ where
         root_dir: PathBuf::from(cargo_manifest_dir),
         out_file: out_file,
         target_triple: env::var("TARGET").expect("could not get target triple"),
-        docs,
+        docs: docs,
     };
 
     run(&config);


### PR DESCRIPTION
This one line blocks compilation on 1.16, and using the old 0.12 version with multiple rust compilers seems to not work due to the issue behind #66.