### PR TITLE
feat: Put the test code inline into the test module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ path = "src/skeptic"
 [dev-dependencies.skeptic]
 path = "src/skeptic"
 
+[dev-dependencies.serde_json]
+version = "1"
+
 # This makes the tests that link to Skeptic in README.md work.
 # It is not needed for normal uses of Skeptic.
 [dependencies.skeptic]

--- a/README.md
+++ b/README.md
@@ -213,13 +213,16 @@ use std::path::PathBuf;
 ```
 <code>```</code>
 
-Templates are [Rust format
-specifiers](http://doc.rust-lang.org/std/fmt/index.html) that must
-take a single argument (i.e. they need to contain the string
-"{}"). See [the (old) template example](template-example.md) for more
-on templates.
+If it is necessary to have module global definitions such as for `#[macro_use]`
+crates the `skeptic-root-template` specifier can be used.
 
-Note that in a template, real braces need to be doubled.
+<code>```rust,skeptic-root-template</code>
+```rust,ignore
+#[macro_use]
+extern crate serde_json;
+```
+<code>```</code>
+
 
 ## The old-style, document-global template
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ of Markdown files.
 
 In `build.rs` write this to test all Rust code blocks in `README.md`:
 
-```rust,no_run
+```rust,no_run,skt-main
 extern crate skeptic;
 
 fn main() {
@@ -46,7 +46,7 @@ you, the method `markdown_files_of_directory` will create such a list,
 enumerating the markdown files in the specified directory. You can add
 more files to this list as you like:
 
-```rust,no_run
+```rust,no_run,skt-main
 extern crate skeptic;
 
 use skeptic::*;
@@ -103,9 +103,7 @@ To indicate Rust code, code blocks are labeled `rust`:
 
 <code>```rust</code>
 ```rust
-fn main() {
-   println!("Calm your skepticism. This example is verified.");
-}
+println!("Calm your skepticism. This example is verified.");
 ```
 <code>```</code>
 
@@ -143,9 +141,7 @@ fn do_amazing_thing() -> i32 {
    unimplemented!()
 }
 
-fn main() {
-   do_amazing_thing();
-}
+do_amazing_thing();
 ```
 <code>```</code>
 
@@ -156,9 +152,7 @@ of a `panic!()`.
 
 <code>```rust,should_panic</code>
 ```rust,should_panic
-fn main() {
-   assert!(1 == 100);
-}
+assert!(1 == 100);
 ```
 <code>```</code>
 
@@ -206,16 +200,16 @@ println!("{:?}", p);
 
 This tells skeptic to look in the template file for another
 markdown block with the same `skt-foo` annotation, and compose
-them together using the standard Rust `format!` macro. Here's
-what the template looks like:
+them together using a [Handlebars][] templates with escaping disabled.
+Here's what the template looks like (the test code is available as `test`):
+
+[Handlebars]:https://github.com./sunng87/handbars-rust
 
 <code>```rust,skt-foo</code>
 ```rust,ignore
 use std::path::PathBuf;
 
-fn main() {{
-    {}
-}}
+{{test}}
 ```
 <code>```</code>
 
@@ -237,9 +231,7 @@ explicitly tagged.
 ```rust,ignore
 use std::path::PathBuf;
 
-fn main() {{
-    {}
-}}
+{{test}}
 ```
 <code>```</code>
 

--- a/README.md.skt.md
+++ b/README.md.skt.md
@@ -1,7 +1,11 @@
 ```rust,skt-foo
 use std::path::PathBuf;
 
-fn main() {{
-    {}
-}}
+{{test}}
+```
+
+```rust,skt-main
+
+{{test}}
+main()
 ```

--- a/README.md.skt.md
+++ b/README.md.skt.md
@@ -1,3 +1,8 @@
+```rust,skeptic-root-template
+#[macro_use]
+extern crate serde_json;
+```
+
 ```rust,skt-foo
 use std::path::PathBuf;
 

--- a/build.rs
+++ b/build.rs
@@ -1,13 +1,12 @@
 extern crate skeptic;
 
 fn main() {
-    skeptic::generate_doc_tests(
-        &[
-            "README.md",
-            "template-example.md",
-            "tests/hashtag-test.md",
-            "tests/should-panic-test.md",
-            "tests/section-names.md",
-        ],
-    );
+    skeptic::generate_doc_tests(&[
+        "README.md",
+        "template-example.md",
+        "tests/macro-use.md",
+        "tests/hashtag-test.md",
+        "tests/should-panic-test.md",
+        "tests/section-names.md",
+    ]);
 }

--- a/src/skeptic/Cargo.toml
+++ b/src/skeptic/Cargo.toml
@@ -23,6 +23,8 @@ walkdir = "2.0"
 serde_json = "1.0.3"
 cargo_metadata = "0.3"
 bytecount = "0.2.0"
+handlebars = "=1.0.0-beta.1"
+failure = "0.1"
 
 [dev-dependencies]
 unindent = "0.1.0"

--- a/src/skeptic/lib.rs
+++ b/src/skeptic/lib.rs
@@ -414,9 +414,6 @@ struct CodeBlockInfo {
 fn emit_tests(config: &Config, suite: DocTestSuite) -> Result<(), failure::Error> {
     let mut out = String::new();
 
-    // Test cases use the api from skeptic::rt
-    out.push_str("extern crate skeptic;\n");
-
     for doc_test in suite.doc_tests {
         if let Some(ref root_template) = doc_test.root_template {
             out.push_str(root_template);

--- a/template-example.md
+++ b/template-example.md
@@ -15,9 +15,7 @@ turn off unused imports, and wrap the example in main:
 #![allow(unused_imports)]
 extern crate skeptic;
 
-fn main() {{
-   {}
-}}
+{{test}}
 
 ```
 <code>```</code>

--- a/tests/hashtag-test.md
+++ b/tests/hashtag-test.md
@@ -2,9 +2,7 @@ Rust code that includes a "`#`" should be tested by skeptic without error.
 
 ```rust
 struct Person<'a>(&'a str);
-fn main() {
-  let _ = Person("#bors");
-}
+let _ = Person("#bors");
 ```
 
 Rust code that includes lines with single "`#`" should be tested by skeptic without error.
@@ -13,9 +11,7 @@ Rust code that includes lines with single "`#`" should be tested by skeptic with
 #
 struct Person<'a>(&'a str);
 #
-fn main() {
-  let _ = Person("#bors");
-}
+let _ = Person("#bors");
 ```
 
 Rust code with hidden parts "`# `" should be tested by skeptic without error.
@@ -23,9 +19,7 @@ Rust code with hidden parts "`# `" should be tested by skeptic without error.
 ```rust
 # struct Person<'a>(&'a str);
 
-fn main() {
-  let _ = Person("bors");
-}
+let _ = Person("bors");
 ```
 
 Rust code that uses attributes `"#["` should be tested by skeptic without error.
@@ -35,9 +29,7 @@ Rust code that uses attributes `"#["` should be tested by skeptic without error.
 struct Person<'a>(&'a str);
 
 #[allow(unused_variables)]
-fn main() {
-  let p = Person("bors");
-}
+let p = Person("bors");
 ```
 
 Rust code that uses crate-level attributes `"#!"` should be tested by skeptic without error.
@@ -46,7 +38,5 @@ Rust code that uses crate-level attributes `"#!"` should be tested by skeptic wi
 #![allow(unused_variables)]
 
 struct Person<'a>(&'a str);
-fn main() {
-  let p = Person("bors");
-}
+let p = Person("bors");
 ```

--- a/tests/macro-use.md
+++ b/tests/macro-use.md
@@ -1,0 +1,5 @@
+# `#[macro_use]` should work
+
+```rust
+println!("{}", json!({ "test": 1 }));
+```

--- a/tests/macro_use.md
+++ b/tests/macro_use.md
@@ -1,0 +1,5 @@
+# `#[macro_use]` should work
+
+```rust
+println!("{}", json!({ "test": 1 }));
+```

--- a/tests/section-names.md
+++ b/tests/section-names.md
@@ -2,25 +2,19 @@
 
 ```rust
 struct Person<'a>(&'a str);
-fn main() {
-  let _ = Person("bors");
-}
+let _ = Person("bors");
 ```
 
 ## !@#$ Test Cases )(() with {}[] non alphanumeric characters ^$23 characters are "`#`" generated correctly @#$@#$  22.
 
 ```rust
 struct Person<'a>(&'a str);
-fn main() {
-  let _ = Person("bors");
-}
+let _ = Person("bors");
 ```
 
 ## Test cases with non ASCII ö_老虎_é characters are generated correctly.
 
 ```rust
 struct Person<'a>(&'a str);
-fn main() {
-  let _ = Person("bors");
-}
+let _ = Person("bors");
 ```

--- a/tests/should-panic-test.md
+++ b/tests/should-panic-test.md
@@ -1,19 +1,6 @@
 Rust code that should panic when running it.
 
 ```rust,should_panic
-fn main() {
-  panic!("I should panic");
-}
+panic!("I should panic");
 ```
 
-Rust code that should panic when compiling it.
-
-```rust,no_run,should_panic
-fn add(a: u32, b: u32) -> u32 {
-    a + b
-}
-
-fn main() {
-  add(1);
-}
-```


### PR DESCRIPTION
This fixes two major issues with skeptic's current implementation at the
cost of losing compile-fail tests. For many crates I expect this to be a
worthwhile tradeoff. It is possible to restore compile-tests but they
would be forced to use the same shelling out approach as before this PR
so they would suffer from the same problem. As such I prefer to keep
them out instead.

No longer shells out to rustc and attempts to emulate cargo's dependency
resolution.

Fixes #18

Tests are now in a normal test module letting cargo cache and reuse
compilation artifacts as normal.

Fixes #8

BREAKING CHANGE

- Handlebars templates are now used instead of `format!`
  Since there is no intermediate step we need a way to dynamically
  template. Handlebars is well known and well supported.

- Compile tests that expect panics are not supported
  Since code is generated inline, these tests would cause test
  compilation to fail