### PR TITLE
update cargo_metadata

### DIFF
--- a/src/skeptic/Cargo.toml
+++ b/src/skeptic/Cargo.toml
@@ -21,7 +21,7 @@ tempdir = "0.3.5"
 glob = "0.2"
 walkdir = "2.0"
 serde_json = "1.0.3"
-cargo_metadata = "0.3"
+cargo_metadata = "0.5"
 bytecount = "0.3.1"
 
 [dev-dependencies]

--- a/src/skeptic/lib.rs
+++ b/src/skeptic/lib.rs
@@ -553,7 +553,10 @@ pub mod rt {
         fn from_path<P: AsRef<Path>>(pth: P) -> Result<LockedDeps> {
             let pth = pth.as_ref().join("Cargo.toml");
             let metadata = cargo_metadata::metadata_deps(Some(&pth), true)?;
-            let workspace_members = metadata.workspace_members;
+            let workspace_members:Vec<String> = metadata.workspace_members
+                .into_iter()
+                .map(|workspace| workspace.name.clone())
+                .collect();
             let deps = metadata.resolve.ok_or("Missing dependency metadata")?
                 .nodes
                 .into_iter()


### PR DESCRIPTION
will there be a new release of the skeptic crate sometime? the current version drags in at least 3 extra dependencies to the rustfmt-nightly crate