### PR TITLE
[travis.yml] Add Rust 1.24.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
 
     # skeptic unit tests
     - os: linux
+      rust: 1.24.0
+    - os: linux
       rust: stable
     - os: linux
       rust: beta


### PR DESCRIPTION
Add Rust 1.24.0 to the matrix, as the minimum supported version.

In future updates, when this test breaks, either the issue is fixed, or the minimum-rust-version is updated to a new desired value.

Fixes GH-85.