### PR TITLE
Add prefix "test" for testcases.

### DIFF
--- a/src/skeptic/lib.rs
+++ b/src/skeptic/lib.rs
@@ -243,9 +243,9 @@ fn extract_tests_from_string(s: &str, file_stem: &str) -> (Vec<Test>, Option<Str
                         old_template = Some(buf.into_iter().collect())
                     } else {
                         let name = if let Some(ref section) = section {
-                            format!("{}_sect_{}_line_{}", file_stem, section, code_block_start)
+                            format!("test_{}_sect_{}_line_{}", file_stem, section, code_block_start)
                         } else {
-                            format!("{}_line_{}", file_stem, code_block_start)
+                            format!("test_{}_line_{}", file_stem, code_block_start)
                         };
                         tests.push(Test {
                             name: name,


### PR DESCRIPTION
Currently tests for files which name beginning of numbers. (ex. "1_one.md", "2_two.md")
It is because function name starts number(from filename).
```
error: expected identifier, found `1_one_line_8`
  |
2 | #[test] fn 1_one_line_8() {
  |            ^^^^^^^^^^^^^ expected identifier
```

Add prefix "test_" and then we can process any name files. 