### PR TITLE
Replace the deprecated tempdir crate

### DIFF
--- a/src/skeptic/Cargo.toml
+++ b/src/skeptic/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "budziq/rust-skeptic" }
 appveyor = { repository = "budziq/rust-skeptic" }
 
 [dependencies]
-tempdir = "0.3"
+tempfile = "3.1"
 glob = "0.3"
 walkdir = "2.2"
 serde_json = "1.0"

--- a/src/skeptic/lib.rs
+++ b/src/skeptic/lib.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate error_chain;
 extern crate pulldown_cmark as cmark;
-extern crate tempdir;
+extern crate tempfile;
 extern crate glob;
 extern crate bytecount;
 
@@ -529,7 +529,7 @@ pub mod rt {
     use std::process::Command;
     use std::ffi::OsStr;
     use std::str::FromStr;
-    use tempdir::TempDir;
+    use tempfile::tempdir;
 
     use self::walkdir::WalkDir;
     use self::serde_json::Value;
@@ -730,7 +730,7 @@ pub mod rt {
 
     pub fn compile_test(root_dir: &str, out_dir: &str, target_triple: &str, test_text: &str) {
         let rustc = &env::var("RUSTC").unwrap_or_else(|_| String::from("rustc"));
-        let outdir = &TempDir::new("rust-skeptic").unwrap();
+        let outdir = tempdir().unwrap();
         let testcase_path = &outdir.path().join("test.rs");
         let binary_path = &outdir.path().join("out.exe");
 
@@ -748,7 +748,7 @@ pub mod rt {
 
     pub fn run_test(root_dir: &str, out_dir: &str, target_triple: &str, test_text: &str) {
         let rustc = &env::var("RUSTC").unwrap_or_else(|_| String::from("rustc"));
-        let outdir = &TempDir::new("rust-skeptic").unwrap();
+        let outdir = tempdir().unwrap();
         let testcase_path = &outdir.path().join("test.rs");
         let binary_path = &outdir.path().join("out.exe");
 


### PR DESCRIPTION
RUSTSEC-2018-0017 says this crate is unmaintained, and to replace it with the tempfile crate instead.

This seems like a simple change that unlocks happier `cargo deny` output for all users of rust-skeptic. Here's how it looks in my project:

```
warning[RUSTSEC-2018-0017]: `tempdir` crate has been deprecated; use `tempfile` instead
    ┌─ /home/lupine/dev/code.ur.gs/lupine/telepathy-padfoot/Cargo.lock:276:1
    │
276 │ tempdir 0.3.7 registry+https://github.com/rust-lang/crates.io-index
    │ ------------------------------------------------------------------- unmaintained advisory detected
    │
    = The [`tempdir`](https://crates.io/crates/tempdir) crate has been deprecated
      and the functionality is merged into [`tempfile`](https://crates.io/crates/tempfile).
    = URL: https://github.com/rust-lang-deprecated/tempdir/pull/46
    = tempdir v0.3.7
      └── skeptic v0.13.4
          └── (build) image-meta v0.1.1
              └── deltachat v1.33.0
                  └── telepathy-padfoot v0.1.0
```

I'm still very new to rust, and my strategy is to throw as many linters as I can at my code to learn what's good and what's bad! It does mean I bump into things like this.

Additionally, my `Cargo.lock` already has a dependency on `tempfile` `v3.1.0`, so this will (marginally !) improve build times.