### PR TITLE
Switch out tempdir for tempfile

### DIFF
--- a/src/skeptic/Cargo.toml
+++ b/src/skeptic/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "budziq/rust-skeptic" }
 appveyor = { repository = "budziq/rust-skeptic" }
 
 [dependencies]
-tempdir = "0.3"
+tempfile = "3.1"
 glob = "0.3"
 walkdir = "2.2"
 serde_json = "1.0"


### PR DESCRIPTION
`tempdir` has been deprecated so this change just switches it out for the equivalent usage with `tempfile`.