### PR TITLE
Fix path to `dll`s on windows

### DIFF
--- a/skeptic/src/rt.rs
+++ b/skeptic/src/rt.rs
@@ -269,8 +269,7 @@ impl Fingerprint {
         let mut dll = rlib.clone();
         rlib.push(format!("deps/lib{}-{}", libname, hash));
         dll.push(format!("deps/{}-{}", libname, hash));
-        rlib = guess_ext(rlib, &["rlib", "so", "dylib"])
-            .or_else(|_| guess_ext(dll, &["dll"]))?;
+        rlib = guess_ext(rlib, &["rlib", "so", "dylib"]).or_else(|_| guess_ext(dll, &["dll"]))?;
 
         Ok(Fingerprint {
             libname,

--- a/skeptic/src/rt.rs
+++ b/skeptic/src/rt.rs
@@ -266,8 +266,11 @@ impl Fingerprint {
         rlib.pop();
         rlib.pop();
         rlib.pop();
+        let mut dll = rlib.clone();
         rlib.push(format!("deps/lib{}-{}", libname, hash));
-        rlib = guess_ext(rlib, &["rlib", "so", "dylib", "dll"])?;
+        dll.push(format!("deps/{}-{}", libname, hash));
+        rlib = guess_ext(rlib, &["rlib", "so", "dylib"])
+            .or_else(|_| guess_ext(dll, &["dll"]))?;
 
         Ok(Fingerprint {
             libname,

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -17,3 +17,8 @@ path = "../skeptic"
 # It is not needed for normal uses of Skeptic.
 [dependencies.skeptic]
 path = "../skeptic"
+
+[dependencies.derive_more]
+version = "0.99"
+default_features = false
+features = ["from"]

--- a/testing/tests/hashtag-test.md
+++ b/testing/tests/hashtag-test.md
@@ -1,9 +1,10 @@
 Rust code that includes a "`#`" should be tested by skeptic without error.
 
 ```rust
+#[derive(derive_more::From)]
 struct Person<'a>(&'a str);
 fn main() {
-  let _ = Person("#bors");
+  let _ = Person::from("#bors");
 }
 ```
 


### PR DESCRIPTION
Resolves #131 

It looks like for some reason `dll`s aren't prefixed with `lib` on windows. 